### PR TITLE
RFC: `btdu.ui.browser`: reorder "Selected" and "Viewing" info panes

### DIFF
--- a/source/btdu/ui/browser.d
+++ b/source/btdu/ui/browser.d
@@ -1216,9 +1216,22 @@ struct Browser
 							assert(itemScrollContext.y.contentSize == items.length);
 						});
 
+						// "Selected:"
+						auto selectionInfoHeight = 0;
+						if (selection) {
+							selectionInfoHeight += height / 2;
+							withWindow(itemsWidth + 1, 0, infoWidth, selectionInfoHeight, {
+								auto moreButton = fmtIf(
+									selection.firstChild !is null,
+									fmtSeq(button("→"), " ", button("i")).valueFunctor,
+									       button("→")                   .valueFunctor,
+								);
+								drawInfoPanel("Selected: ", moreButton, false, ScrollContext.init, selection);
+							});
+						}
+
 						// "Viewing:"
-						auto currentInfoHeight = selection ? height / 2 : height;
-						withWindow(itemsWidth + 1, 0, infoWidth, currentInfoHeight, {
+						withWindow(itemsWidth + 1, selectionInfoHeight, infoWidth, height - selectionInfoHeight, {
 							if (currentPath is &marked)
 							{
 								updateMark();
@@ -1228,24 +1241,13 @@ struct Browser
 								drawInfoPanel("Viewing: ", button("i"), false, ScrollContext.init, currentPath);
 						});
 
-						// "Selected:"
-						if (selection)
-							withWindow(itemsWidth + 1, currentInfoHeight, infoWidth, height - currentInfoHeight, {
-								auto moreButton = fmtIf(
-									selection.firstChild !is null,
-									fmtSeq(button("→"), " ", button("i")).valueFunctor,
-									       button("→")                   .valueFunctor,
-								);
-								drawInfoPanel("Selected: ", moreButton, false, ScrollContext.init, selection);
-							});
-
 						// Vertical separator
 						foreach (y; 0 .. height)
 							at(itemsWidth, y, {
 								write(
-									y == 0                 ? '╦' :
-									y == currentInfoHeight ? '╠' :
-									                         '║'
+									y == 0                   ? '╦' :
+									y == selectionInfoHeight ? '╠' :
+									                           '║'
 								);
 							});
 


### PR DESCRIPTION
## Summary

I have noticed that when I'm exploring the directory hierarchy btdu has built, my eyes are constantly moving back and forth between the cursor position (on the left, most likely in the upper half of the screen) and the info pane representing the entry under cursor (on the bottom right).

This means that the view point has to travel across all of the screen and I often find myself looking the top info pane only to realize that it's not the one I should be looking at.

Perhaps it would be more ergonomic to switch them, considering that most of the time the height of the file list is less than 3/4 of the screen?

Attached is a totally unscientific comparison of the existing and new behavior.

---

### Existing behavior
![eye travel - old](https://github.com/CyberShadow/btdu/assets/1158172/b0cd80f0-9685-48dd-811f-6b69d24efcc6)

### Proposed behavior
![eye travel - new](https://github.com/CyberShadow/btdu/assets/1158172/76b10d5a-af3f-42c2-807f-93e31ca745d9)
