### PR TITLE
flake.nix: compile zlibLto with -nostdlib

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -144,7 +144,7 @@
               configurePhase = ''
                 # Use musl headers and disable glibc's FORTIFY_SOURCE
                 # Note: -w suppresses all warnings, needed because zlib's configure checks for any stderr output
-                export CC="${pkgs.llvmPackages.clang-unwrapped}/bin/clang --target=${targetTriple}"
+                export CC="${pkgs.llvmPackages.clang-unwrapped}/bin/clang --target=${targetTriple} -nostdlib"
                 export AR="${pkgs.llvmPackages.bintools-unwrapped}/bin/llvm-ar"
                 export RANLIB="${pkgs.llvmPackages.bintools-unwrapped}/bin/llvm-ranlib"
                 export CFLAGS="-isystem ${muslLibc.dev}/include -flto=thin -O2 -U_FORTIFY_SOURCE -w"


### PR DESCRIPTION
This has suddently started failing when building on NixOS 25.11.

    gzread.c:24:5: error: use of undeclared identifier 'errno'
       24 |     errno = 0;
          |     ^~~~~
    gzread.c:36:13: error: use of undeclared identifier 'errno'
       36 |         if (errno == EAGAIN || errno == EWOULDBLOCK) {
          |             ^~~~~
    gzread.c:36:22: error: use of undeclared identifier 'EAGAIN'
       36 |         if (errno == EAGAIN || errno == EWOULDBLOCK) {
          |                      ^~~~~~
    gzread.c:36:32: error: use of undeclared identifier 'errno'
       36 |         if (errno == EAGAIN || errno == EWOULDBLOCK) {
          |                                ^~~~~
    gzread.c:36:41: error: use of undeclared identifier 'EWOULDBLOCK'
       36 |         if (errno == EAGAIN || errno == EWOULDBLOCK) {
          |                                         ^~~~~~~~~~~
    5 errors generated.