### PR TITLE
flake.nix: reuse pkgs.ldc.src to match ldc-build-runtime

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -93,13 +93,8 @@
         # ============================================================
 
         # LDC source for building runtime (with ARM musl patch applied)
-        ldcSrcUnpatched = pkgs.fetchFromGitHub {
-          owner = "ldc-developers";
-          repo = "ldc";
-          tag = "v${pkgs.ldc.version}";
-          hash = "sha256-6LcpY3LSFK4KgEiGrFp/LONu5Vr+/+vI04wEEpF3s+s=";
-          fetchSubmodules = true;
-        };
+        # - Reuse nixpkgs' own LDC source so it always matches the ldc-build-runtime
+        ldcSrcUnpatched = pkgs.ldc.src;
 
         # Apply ARM musl patches to LDC source
         # - stat.d: Add stat_t for musl ARM (correct struct size)


### PR DESCRIPTION
On current `nixpkgs-unstable` the `ldc-build-runtime` has diverged from the pinned `ldcSrcUnpatched`. It's safer to just reuse the `pkgs.ldc.src` from nixpkgs directly. At some point the patches might no longer apply, though.

```console
$ nix build --override-input nixpkgs "github:NixOS/nixpkgs/nixpkgs-unstable" .#btdu-static-x86_64
warning: not writing modified lock file of flake 'git+file:///tmp/btdu':
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/2fb006b87f04c4d3bdf08cfdbc7fab9c13d94a15?narHash=sha256-kJ8lIZsiPOmbkJypG%2BB5sReDXSD1KGu2VEPNqhRa/ew%3D' (2025-10-31)
  → 'github:NixOS/nixpkgs/ac6b2166e7a9375683b8e98f860f273222337b16?narHash=sha256-vMiXptXarfSdJb1Gkc%2BFYVOAibuBRj7qxGa8z68q1Uw%3D' (2026-08-25)
error: Cannot build '/nix/store/25adgi907r3a78gcq79inhvnjjpk4ax4-ldc-runtime-x86_64-1.42.0.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/3sx3p4s9cl526jp7hl5pi59pw6zp9cwa-ldc-runtime-x86_64-1.42.0
       Last 16 log lines:
       > .: Creating build directory: ldc-build-runtime.tmp
       > .: Invoking: cmake -DLDC_EXE_FULL=/nix/store/wf7rd7h1yrhfmiqc60jpp4j7mqgymnq2-ldc-1.42.0/bin/ldc2 -DLDMD_EXE_FULL=/nix/store/wf7rd7h1yrhfmiqc60jpp4j7mqgymnq2-ldc-1.42.0/bin/ldmd2 -DDMDFE_MINOR_VERSION=112 -DDMDFE_PATCH_VERSION=1 '-DD_EXTRA_FLAGS=-mtriple=x86_64-unknown-linux-musl;-flto=full;-O;--release' -DBUILD_SHARED_LIBS=OFF -G Ninja /nix/store/p4c6rwqcwf8di1gjp08qs1067jmnmfws-ldc-src-patched-1.42.0/runtime
       > -- The C compiler identification is GNU 15.3.0
       > -- The ASM compiler identification is GNU
       > -- Found assembler: /nix/store/x71clgf0dx6bf66cmrnz19wxbkd02ml0-x86_64-unknown-linux-musl-gcc-wrapper-15.3.0/bin/x86_64-unknown-linux-musl-cc
       > -- Detecting C compiler ABI info
       > -- Detecting C compiler ABI info - done
       > -- Check for working C compiler: /nix/store/x71clgf0dx6bf66cmrnz19wxbkd02ml0-x86_64-unknown-linux-musl-gcc-wrapper-15.3.0/bin/x86_64-unknown-linux-musl-cc - skipped
       > -- Detecting C compile features
       > -- Detecting C compile features - done
       > CMake Error at CMakeLists.txt:17 (message):
       >   Please define the CMake variable LDC_WITH_LLD.
       >
       > 
       > -- Configuring incomplete, errors occurred!
       > .: Error: command failed with status 1
       For full logs, run:
         nix log /nix/store/25adgi907r3a78gcq79inhvnjjpk4ax4-ldc-runtime-x86_64-1.42.0.drv
error: Cannot build '/nix/store/iw59zw1dyzjsvn14srsgcd9qnqb8d2jr-btdu-static-x86_64-0.7.2.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/ijkck9kcnbcicn50ij96dscil1mrnnip-btdu-static-x86_64-0.7.2
```